### PR TITLE
Create 'uptime' Plugin to Display Server Uptime

### DIFF
--- a/uptime/uptime.go
+++ b/uptime/uptime.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2012 VMware, Inc. - https://github.com/cloudfoundry/gosigar/blob/master/examples/uptime.go
+
+package uptime
+
+import (
+	"fmt"
+	"github.com/cloudfoundry/gosigar"
+	"time"
+	"github.com/go-chat-bot/bot"
+)
+
+func uptime(command *bot.Cmd) (msg string, err error) {
+	uptime := sigar.Uptime{}
+	uptime.Get()
+	avg := sigar.LoadAverage{}
+	avg.Get()
+	msg = fmt.Sprintf("%s up %s load average: %.2f, %.2f, %.2f\n", time.Now().Format("15:04:05"),	uptime.Format(), avg.One, avg.Five, avg.Fifteen)
+	return
+}
+
+func init() {
+	bot.RegisterCommand(
+		"uptime",
+		"Sends the uptime of your server to you on the channel.",
+		"",
+		uptime)
+}


### PR DESCRIPTION
Server uptime ported from: https://github.com/cloudfoundry/gosigar/blob/master/examples/uptime.go

```
zfouts [12:11 AM]
!uptime
gobotAPP [12:11 AM]
07:11:41 up 135 days,  5:03 load average: 0.00, 0.01, 0.03
```