### PR TITLE
[jira] Verify that projects referenced by issues exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ These commands differ from the active commands as they are executed for every te
 
 * **url**: Detects url and gets it's title (very naive implementation, works sometimes)
 * **catfacts**: Tells a random cat fact based on some cat keywords
-* **jira**: Detects jira issue numbers and posts the url (necessary to configure the JIRA URL)
+* **jira**: Detects jira issue numbers and posts information about it. Necessary
+  to configure. See README.md in jira subdirectory for details
 * **chucknorris**: Shows a random chuck norris quote every time the word "chuck" is mentioned
 
 ### Periodic (triggers)

--- a/jira/README.md
+++ b/jira/README.md
@@ -1,0 +1,18 @@
+### Overview
+
+This is a plugin for [Atlassian JIRA](https://www.atlassian.com/software/jira)
+issue tracking system.
+
+### Features
+* Simple authentication support for JIRA
+* Posts full link when JIRA issues are mentioned on the channels
+
+### Setup
+* Set up JIRA_BASE_URL env variable to your JIRA server URL. For example
+  https://issues.jenkins-ci.org
+* Set up JIRA_USER env variable to JIRA username for the bot account
+* Set up JIRA_PASS env variable to JIRA password for the bot account
+
+### TODO
+* Output some of the issue details in the channels not just links
+* Notifications when new issues are created

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	pattern    = ".*?([A-Z]+)-([0-9]+)\\b"
-	env        = "JIRA_ISSUES_URL"
 	userEnv    = "JIRA_USER"
 	passEnv    = "JIRA_PASS"
 	baseURLEnv = "JIRA_BASE_URL"
@@ -82,10 +81,10 @@ func jira(cmd *bot.PassiveCmd) (bot.CmdResultV3, error) {
 
 func init() {
 	var err error
-	url = os.Getenv(env)
 	jiraUser = os.Getenv(userEnv)
 	jiraPass = os.Getenv(passEnv)
 	baseURL = os.Getenv(baseURLEnv)
+	url = baseURL + "/browse/"
 
 	tp := gojira.BasicAuthTransport{
 		Username: jiraUser,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -4,11 +4,10 @@ import (
 	"github.com/go-chat-bot/bot"
 	"os"
 	"regexp"
-	"strings"
 )
 
 const (
-	pattern = "(^|\\s)+[A-z]{3}-[0-9]+\\b"
+	pattern = ".*?([A-Z]+)-([0-9]+)\\b"
 	env     = "JIRA_ISSUES_URL"
 )
 
@@ -17,25 +16,41 @@ var (
 	re  = regexp.MustCompile(pattern)
 )
 
-func getIssue(text string) string {
-	if re.MatchString(text) {
-		return re.FindString(text)
+func getIssues(text string) [][2]string {
+	matches := re.FindAllStringSubmatch(text, -1)
+	var data [][2]string
+	for _, match := range matches {
+		// match[1] == project key
+		// match[2] == issue number
+		data = append(data, [2]string{match[1], match[2]})
 	}
-	return ""
+	return data
 }
 
-func jira(cmd *bot.PassiveCmd) (string, error) {
-	issue := getIssue(cmd.Raw)
-	if issue != "" {
-		return url + strings.ToUpper(strings.TrimSpace(issue)), nil
+func jira(cmd *bot.PassiveCmd) (bot.CmdResultV3, error) {
+	result := bot.CmdResultV3{
+		Message: make(chan string),
+		Done:    make(chan bool, 1)}
+	result.Channel = cmd.Channel
+	issues := getIssues(cmd.Raw)
+	if issues != nil {
+		go func() {
+			for _, issue := range issues {
+				key, num := issue[0], issue[1]
+				result.Message <- url + key + "-" + num
+			}
+			result.Done <- true
+		}()
+	} else {
+		result.Done <- true
 	}
 
-	return "", nil
+	return result, nil
 }
 
 func init() {
 	url = os.Getenv(env)
-	bot.RegisterPassiveCommand(
+	bot.RegisterPassiveCommandV2(
 		"jira",
 		jira)
 }

--- a/jira/jira_test.go
+++ b/jira/jira_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"fmt"
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/go-chat-bot/bot"
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
@@ -9,6 +10,8 @@ import (
 
 func TestJira(t *testing.T) {
 	url = "https://example.atlassian.net/browse/"
+	projects["BOT"] = gojira.Project{}
+	projects["MON"] = gojira.Project{}
 	Convey("Given a text", t, func() {
 		cmd := &bot.PassiveCmd{}
 		Convey("When the text does not match a jira issue syntax", func() {
@@ -69,7 +72,16 @@ func TestJira(t *testing.T) {
 			So(<-s.Message, ShouldEqual, fmt.Sprintf("%s%s", url, "BOT-234"))
 			So(<-s.Message, ShouldEqual, fmt.Sprintf("%s%s", url, "BOT-321"))
 			So(s.Message, ShouldBeEmpty)
-			So(<- s.Done, ShouldEqual, true)
+			So(<-s.Done, ShouldEqual, true)
+		})
+
+		Convey("When jira from non-existing project is mentioned", func() {
+			cmd.Raw = "I saw this NON-123 issue once!"
+			s, err := jira(cmd)
+
+			So(err, ShouldBeNil)
+			So(s.Message, ShouldBeEmpty)
+			So(<-s.Done, ShouldEqual, true)
 		})
 	})
 }


### PR DESCRIPTION
This is a bigger change that should probably be split into smaller steps.
Changes:
 * Adds 3 new env variables for base url, username and password
 * Actually use JIRA API (with basic auth) to get list of actual projects
 * Only output JIRA issues if their projects exist in JIRA
 * Use alternative passive method registration to allow multiple issues being
   mentioned in single message
 * Tweak regex pattern so only upper-caps are taken into account but allow
   non-whitespace preceding characters

Maybe alternative "simple" mode could be preserved - for example if
JIRA_BASE_URL is not set, keep working in the old way?

This also needs tweaks to tests (tbd depending if the general direction is OK).

I have further changes planned wrt actually being able to output summary and other info from the issues to the channels instead of just simple link

Related to #33 