### PR TITLE
New plugin to shorten URLs in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These commands differ from the active commands as they are executed for every te
 * **jira**: Detects jira issue numbers and posts information about it. Necessary
   to configure. See README.md in jira subdirectory for details
 * **chucknorris**: Shows a random chuck norris quote every time the word "chuck" is mentioned
+* **bitly**: Shortens URLs appearing in output of other plugins before they are sent to channels
 
 ### Periodic (triggers)
 

--- a/bitly/bitly.go
+++ b/bitly/bitly.go
@@ -1,0 +1,48 @@
+package bitly
+
+import (
+	"github.com/go-chat-bot/bot"
+	"github.com/mvdan/xurls"
+	"github.com/zpnk/go-bitly"
+	"log"
+	"os"
+	"strings"
+)
+
+const (
+	bitlyTokenEnv = "BITLY_TOKEN"
+)
+
+var (
+	bitlyClient *bitly.Client
+	urlRegex    = xurls.Strict()
+)
+
+func bitlyFilter(cmd *bot.FilterCmd) (string, error) {
+	urls := urlRegex.FindAllString(cmd.Message, -1)
+	if urls == nil {
+		// no urls to shorten
+		return cmd.Message, nil
+	}
+
+	for _, url := range urls {
+		shortURL, err := bitlyClient.Links.Shorten(url)
+		if err != nil {
+			log.Printf("Failed to shorten URL (%s): %s", url, err.Error())
+			continue
+		}
+		cmd.Message = strings.Replace(cmd.Message,
+			url, shortURL.URL, -1)
+	}
+
+	return cmd.Message, nil
+}
+
+func init() {
+	token := os.Getenv(bitlyTokenEnv)
+	bitlyClient = bitly.New(token)
+
+	bot.RegisterFilterCommand(
+		"bitly",
+		bitlyFilter)
+}


### PR DESCRIPTION
It uses bitly library and new filter functionality to shorten URLs that
other plugins might be sending to the channels. This means other plugins
do not need to implement their own shortening - this plugin will do it
for them.