### PR TITLE
Add dedup plugin

### DIFF
--- a/dedup/README.md
+++ b/dedup/README.md
@@ -1,0 +1,9 @@
+### Overview
+
+This plugin de-duplicates messages sent by the bot. This can be useful to
+prevent bot from repeating the same answer repeatedly within a period of time.
+
+### Setup
+Set up DEDUP_TIMEOUT env variable to number of minutes which should be
+de-duplicated. Plugin defaults to 5 minutes of de-duplication unless configured
+otherwise

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -1,0 +1,69 @@
+package dedup
+
+import (
+	"github.com/go-chat-bot/bot"
+	"hash/fnv"
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	dedupConfigEnv   = "DEDUP_TIMEOUT"
+	defaultDedupTime = "5"
+)
+
+var (
+	pastMessageMap map[uint32]time.Time
+	dedupConfig    time.Duration
+	fnvHash        = fnv.New32a()
+)
+
+func messageHash(msg, target string) uint32 {
+	fnvHash.Write([]byte(msg))
+	fnvHash.Write([]byte(target))
+	defer fnvHash.Reset()
+	return fnvHash.Sum32()
+}
+
+func recordMessage(msgHash uint32, target string) {
+	until := time.Now().UTC().Add(dedupConfig)
+	pastMessageMap[msgHash] = until
+	go func() {
+		time.Sleep(dedupConfig)
+		delete(pastMessageMap, msgHash)
+	}()
+}
+
+func dedupFilter(cmd *bot.FilterCmd) (string, error) {
+	msgHash := messageHash(cmd.Message, cmd.Target)
+	_, found := pastMessageMap[msgHash]
+	if !found {
+		// No past message like this, record and send
+		recordMessage(msgHash, cmd.Target)
+		return cmd.Message, nil
+	}
+
+	// Past message found, filter out!
+	log.Printf("Deduplicating message in %s\n", cmd.Target)
+	return "", nil
+}
+
+func init() {
+	pastMessageMap = make(map[uint32]time.Time)
+	dedupVar := os.Getenv(dedupConfigEnv)
+	if dedupVar == "" {
+		dedupVar = defaultDedupTime
+	}
+	min, err := strconv.Atoi(dedupVar)
+	if err != nil {
+		log.Printf("Failed to load dedup configuration. Falling back to	default")
+		min, _ = strconv.Atoi(defaultDedupTime)
+	}
+	dedupConfig = time.Duration(min) * time.Minute
+
+	bot.RegisterFilterCommand(
+		"dedup",
+		dedupFilter)
+}


### PR DESCRIPTION
This provides way to de-duplicate messages sent by bot into channels for
a period of time. For example if someone requests the same information
over and over the bot will ignore/not repeat the same response within
configured time again