### PR TITLE
[jira] Add support for custom new/resolved format

### DIFF
--- a/jira/README.md
+++ b/jira/README.md
@@ -21,6 +21,8 @@ variable `JIRA_CONFIG_FILE`. Example file can be seen in
 configuration having:
  * `channel` for which the configuration is intended
  * `template` to override default issue template (see Issue Formatting)
+ * `templateNew` to override default issue template for new issue notifications
+ * `templateResolved` to override default issue template for resolved issue notifications
  * `notifyNew` is array of JIRA project keys to watch for new issues
  * `notifyResolved` is array JIRA project keys to watch for resolved issues
 

--- a/jira/example_config.json
+++ b/jira/example_config.json
@@ -2,7 +2,8 @@
     {
         "channel": "#gojirabot",
         "notifyNew": ["JENKINS"],
-        "notifyResolved": ["JENKINS"]
+        "notifyResolved": ["JENKINS"],
+        "templateNew": "New {{.Fields.Type.Name}} reported by {{.Fields.Reporter.Key}}: {.Key}"
     },
     {
         "channel": "#gojira-test",


### PR DESCRIPTION
Original code forced new/resolved issues format to be identical to
normal replies with hard-coded prefix. This change preserves old
behaviour by default, but adds a way to override per-channel with custom
formatting. For example mentioning reporter when new issues are reported
but otherwise omitting it from the message.