### PR TITLE
Fix up cron spec for new cron version

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -328,16 +328,19 @@ func init() {
 		bot.RegisterPeriodicCommandV2(
 			"periodicJIRANotifyNew",
 			bot.PeriodicConfig{
-				CronSpec:  fmt.Sprintf("0 */%d * * * *", notifyInterval),
+				CronSpec:  fmt.Sprintf("*/%d * * * *", notifyInterval),
 				CmdFuncV2: periodicJIRANotifyNew,
 			})
 	}
+	log.Printf("New issue notifications set up for %d JIRA projects", len(notifyNewConfig))
 	if len(notifyResConfig) > 0 {
 		bot.RegisterPeriodicCommandV2(
 			"periodicJIRANotifyResolved",
 			bot.PeriodicConfig{
-				CronSpec:  fmt.Sprintf("0 */%d * * * *", notifyInterval),
+				CronSpec:  fmt.Sprintf("*/%d * * * *", notifyInterval),
 				CmdFuncV2: periodicJIRANotifyResolved,
 			})
 	}
+	log.Printf("Resolved issue notifications set up for %d JIRA projects", len(notifyResConfig))
+	log.Printf("JIRA plugin initialization successful")
 }


### PR DESCRIPTION
There were changes in https://github.com/robfig/cron which removed the
non-standard seconds field. This in turn broke the cron usage in go-chat-bot.

This is a temporary fix, more likely a larger change in go-chat-bot
might be warranted if we want to preserve compatibility. But it might be easier to just move on to the  new defaults across the board?