### PR TITLE
Add support for authentication using Jira Personal Access Tokens

### DIFF
--- a/jira/README.md
+++ b/jira/README.md
@@ -13,6 +13,8 @@ issue tracking system.
   https://issues.jenkins-ci.org
 * Set up JIRA_USER env variable to JIRA username for the bot account
 * Set up JIRA_PASS env variable to JIRA password for the bot account
+* Optional: set up JIRA_TOKEN env variable, if your instance requires
+  using personal access tokens (user/pass no longer need to be defined).
 
 In addition to the above channel-specific configuration variables can be defined
 in a separate JSON configuration file loaded from path specified by environment

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -239,18 +239,18 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 func initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken string) error {
 	var err error
 
-	tp := gojira.BasicAuthTransport{
-		Username: jiraUser,
-		Password: jiraPass,
-	}
-
   if len(jiraToken) > 0 {
-    tp = gojira.PATAuthTransport {
+    tpPATA := gojira.PATAuthTransport {
       Token: jiraToken,
     }
+    client, err = gojira.NewClient(tpPATA.Client(), baseURL)
+  } else {
+	  tpBA := gojira.BasicAuthTransport{
+  		Username: jiraUser,
+  		Password: jiraPass,
+  	}
+    client, err = gojira.NewClient(tpBA.Client(), baseURL)
   }
-
-	client, err = gojira.NewClient(tp.Client(), baseURL)
 	if err != nil {
 		log.Printf("Error initializing JIRA client: %v\n", err)
 		return err

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -245,10 +245,10 @@ func initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken string) error {
     }
     client, err = gojira.NewClient(tpPATA.Client(), baseURL)
   } else {
-	  tpBA := gojira.BasicAuthTransport{
-  		Username: jiraUser,
-  		Password: jiraPass,
-  	}
+    tpBA := gojira.BasicAuthTransport{
+      Username: jiraUser,
+      Password: jiraPass,
+    }
     client, err = gojira.NewClient(tpBA.Client(), baseURL)
   }
 	if err != nil {

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -244,6 +244,12 @@ func initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken string) error {
 		Password: jiraPass,
 	}
 
+  if len(jiraToken) > 0 {
+    tp := gojira.PATAuthTransport {
+      Token: jiraToken,
+    }
+  }
+
 	client, err = gojira.NewClient(tp.Client(), baseURL)
 	if err != nil {
 		log.Printf("Error initializing JIRA client: %v\n", err)

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -19,6 +19,7 @@ const (
 	pattern           = ".*?([A-Z]+)-([0-9]+)\\b"
 	userEnv           = "JIRA_USER"
 	passEnv           = "JIRA_PASS"
+	tokenEnv          = "JIRA_TOKEN"
 	baseURLEnv        = "JIRA_BASE_URL"
 	channelConfigEnv  = "JIRA_CONFIG_FILE"
 	notifyIntervalEnv = "JIRA_NOTIFY_INTERVAL"
@@ -235,7 +236,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 	return ret, nil
 }
 
-func initJIRAClient(baseURL, jiraUser, jiraPass string) error {
+func initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken string) error {
 	var err error
 
 	tp := gojira.BasicAuthTransport{
@@ -301,11 +302,12 @@ func init() {
 
 	jiraUser := os.Getenv(userEnv)
 	jiraPass := os.Getenv(passEnv)
+	jiraToken := os.Getenv(tokenEnv)
 	baseURL := os.Getenv(baseURLEnv)
 	confFile := os.Getenv(channelConfigEnv)
 	url = baseURL + "/browse/"
 
-	err := initJIRAClient(baseURL, jiraUser, jiraPass)
+	err := initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken)
 	if err != nil {
 		log.Printf("Error querying JIRA for projects: %v\n", err)
 		return

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -245,7 +245,7 @@ func initJIRAClient(baseURL, jiraUser, jiraPass, jiraToken string) error {
 	}
 
   if len(jiraToken) > 0 {
-    tp := gojira.PATAuthTransport {
+    tp = gojira.PATAuthTransport {
       Token: jiraToken,
     }
   }


### PR DESCRIPTION
Newer versions of Jira Cloud supports authenticating users via Personal Access Tokens, instead of basic user/pass. This PR adds support for that feature, by the use of the JIRA_TOKEN variable.

There's only one problem (sorry for the quesiton, Go is not my strong suit): this features requires a minimum of a [specific branch on an upstream module](https://github.com/andygrunwald/go-jira/commit/92a5749ed5eca921771ae5bc1e6cb6d66ffa7f69). This module is [declared in the main application](https://github.com/go-chat-bot/bot/blob/master/go.mod#L6), but the version referenced there is too old, and the code is not in any new release. How do we go about updating that reference?