### PR TITLE
Jira plugin: add support for Components and Google Chat Threads

### DIFF
--- a/jira/README.md
+++ b/jira/README.md
@@ -49,6 +49,24 @@ Default template looks like this:
 `JIRA_NOTIFY_INTERVAL` environment variable can be used to control how often the
 notification methods will be run. It defaults to be run every minute.
 
+### Threaded notifications
+**NOTE:** This feature has only been tested in Google Chat. The person who wrote this code
+          does not use this bot in any other platform. Feel free to contribute to make it
+          work in your prefered platform (in case it supports threads).
+
+In Google Chat, each notification will create a new thread by default. In some cases, it might
+be desirable to restrict to a single thread, for cleaningness. Due to a limitation in the API,
+the thread must exist first. Once a thread is created, you must fetch the full URL. There are
+many different methods for this, so use whatever is better for you, but a thread URL
+should look similar to one of these examples:
+* `https://chat.google.com/room/<roomID>/<threadID>`
+* `https://mail.google.com/chat/u/0/#chat/space/<roomID>/<threadID>`
+
+Once you have that information, your `JIRA_CONFIG_FILE` should look like
+[example_config_thread.json](example_config_thread.json).
+
+Also you, need to start the bot with `JIRA_THREAD=true` environment variable defined.
+
 ### Verbose log
 If JIRA_VERBOSE variable is defined (any value) the bot generates a log
 every time it queries JIRA.

--- a/jira/README.md
+++ b/jira/README.md
@@ -26,7 +26,8 @@ configuration having:
  * `templateNew` to override default issue template for new issue notifications
  * `templateResolved` to override default issue template for resolved issue notifications
  * `notifyNew` is array of JIRA project keys to watch for new issues
- * `notifyResolved` is array JIRA project keys to watch for resolved issues
+ * `notifyResolved` is array of JIRA project keys to watch for resolved issues
+ * `components` (optional) is array of the specific JIRA project components to watch
 
 ### Issue Formatting
 

--- a/jira/example_config_thread.json
+++ b/jira/example_config_thread.json
@@ -1,0 +1,8 @@
+[
+    {
+        "channel": "spaces/AXYZIF4-ABC",
+        "thread": "threads/LMNOPQRggSE",
+        "notifyNew": ["JENKINS"],
+        "notifyResolved": ["JENKINS"]
+    }
+]

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -180,6 +180,10 @@ func periodicJIRANotifyNew() (ret []bot.CmdResult, err error) {
 	for _, issue := range newIssues {
 		channels := notifyNewConfig[issue.Fields.Project.Key]
 		for _, notifyChan := range channels {
+			threadName := channelConfigs[notifyChan].Thread
+			if thread {
+				notifyChan += ":" + notifyChan + "/" + threadName
+			}
 			if verbose {
 				log.Printf("Notifying %s about new %s %s", notifyChan,
 					issue.Fields.Type.Name,
@@ -221,7 +225,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		for _, notifyChan := range channels {
 			threadName := channelConfigs[notifyChan].Thread
 			if thread {
-				notifyChan += ":" + notifyChan + threadName
+				notifyChan += ":" + notifyChan + "/" + threadName
 			}
 			if verbose {
 				log.Printf("Notifying %s about resolved %s %s", notifyChan,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -168,9 +168,16 @@ func periodicJIRANotifyNew() (ret []bot.CmdResult, err error) {
 	for k := range notifyNewConfig {
 		newProjectKeys = append(newProjectKeys, k)
 	}
+	componentsKeys := make([]string, 0, len(componentsConfig))
+	for k := range componentsConfig {
+		componentsKeys = append(componentsKeys, k)
+	}
 
-	query := fmt.Sprintf(newJQL, strings.Join(newProjectKeys, ","),
-		notifyInterval)
+	query := fmt.Sprintf(projectJQL, strings.Join(newProjectKeys, ","))
+	if len(componentsKeys) > 0 {
+		query += fmt.Sprintf(componentJQL, strings.Join(componentsKeys, ","))
+	}
+	query += fmt.Sprintf(newJQL, notifyInterval)
 	if verbose {
 		log.Printf("New issues query: %s", query)
 	}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -182,6 +182,9 @@ func periodicJIRANotifyNew() (ret []bot.CmdResult, err error) {
 		log.Printf("New issues query: %s", query)
 	}
 	newIssues, _, err := client.Issue.Search(query, nil)
+	if verbose {
+		log.Printf("New issues result: %s", newIssues)
+	}
 	if err != nil {
 		log.Printf("Error querying JIRA for new issues: %v\n", err)
 		return nil, err

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -216,7 +216,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		componentsKeys = append(componentsKeys, k)
 	}
 
-	query := fmt.Sprintf(resolvedJQL, strings.Join(resolvedProjectKeys, ","))
+	query := fmt.Sprintf(projectJQL, strings.Join(resolvedProjectKeys, ","))
 	if len(componentsKeys) > 0 {
 		query += fmt.Sprintf(componentJQL, strings.Join(componentsKeys, ","))
 	}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -224,7 +224,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		channels := notifyResConfig[issue.Fields.Project.Key]
 		for _, notifyChan := range channels {
 			threadName := channelConfigs[notifyChan].Thread
-			if thread {
+			if thread && (len(threadName) > 0) {
 				notifyChan += ":" + notifyChan + "/" + threadName
 			}
 			if verbose {

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -234,7 +234,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 	}
 	resolvedIssues, _, err := client.Issue.Search(query, nil)
 	if verbose {
-		log.Printf("Resolved issues result: %s", spew.Sdump(resolvedIssues))
+		log.Printf("Resolved issues result: %s", spew.Sdump(resolvedIssues.Components))
 	}
 	if err != nil {
 		log.Printf("Error querying JIRA for resolved issues: %v\n", err)

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -57,6 +57,7 @@ var (
 
 type channelConfig struct {
 	Channel          string   `json:"channel"`
+	Thread           string   `json:"thread,omitempty"`
 	Template         string   `json:"template,omitempty"`         // template format for issues being posted
 	TemplateNew      string   `json:"templateNew,omitempty"`      // template format for newly created issues
 	TemplateResolved string   `json:"templateResolved,omitempty"` // template format for resolved issues
@@ -217,9 +218,10 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 	}
 	for _, issue := range resolvedIssues {
 		channels := notifyResConfig[issue.Fields.Project.Key]
+		threadName := notifyResConfig[issue.Fields.Thread.Key][0]
 		for _, notifyChan := range channels {
 			if thread {
-				notifyChan += ":" + notifyChan + "/threads/jiraThread"
+				notifyChan += ":" + notifyChan + "/threads/" + threadName
 			}
 			if verbose {
 				log.Printf("Notifying %s about resolved %s %s", notifyChan,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -219,7 +219,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		channels := notifyResConfig[issue.Fields.Project.Key]
 		for _, notifyChan := range channels {
 			if thread {
-				notifyChan += ":spaces/" + notifyChan + "/threads/jiraThread"
+				notifyChan += ":" + notifyChan + "/threads/jiraThread"
 			}
 			if verbose {
 				log.Printf("Notifying %s about resolved %s %s", notifyChan,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -234,7 +234,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 	}
 	resolvedIssues, _, err := client.Issue.Search(query, nil)
 	if verbose {
-		log.Printf("Resolved issues result: %s", spew.Dump(resolvedIssues))
+		log.Printf("Resolved issues result: %s", spew.Sdump(resolvedIssues))
 	}
 	if err != nil {
 		log.Printf("Error querying JIRA for resolved issues: %v\n", err)

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -219,7 +219,7 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		channels := notifyResConfig[issue.Fields.Project.Key]
 		for _, notifyChan := range channels {
 			if thread {
-				notifyChan += ":jiraThread"
+				notifyChan += ":spaces/" + notifyChan + "/threads/jiraThread"
 			}
 			if verbose {
 				log.Printf("Notifying %s about resolved %s %s", notifyChan,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -181,7 +181,7 @@ func periodicJIRANotifyNew() (ret []bot.CmdResult, err error) {
 		channels := notifyNewConfig[issue.Fields.Project.Key]
 		for _, notifyChan := range channels {
 			threadName := channelConfigs[notifyChan].Thread
-			if thread {
+			if thread && (len(threadName) > 0) {
 				notifyChan += ":" + notifyChan + "/" + threadName
 			}
 			if verbose {

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	gojira "github.com/andygrunwald/go-jira"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-chat-bot/bot"
 )
 
@@ -182,9 +183,6 @@ func periodicJIRANotifyNew() (ret []bot.CmdResult, err error) {
 		log.Printf("New issues query: %s", query)
 	}
 	newIssues, _, err := client.Issue.Search(query, nil)
-	if verbose {
-		log.Printf("New issues result: %s", newIssues)
-	}
 	if err != nil {
 		log.Printf("Error querying JIRA for new issues: %v\n", err)
 		return nil, err
@@ -235,6 +233,9 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 		log.Printf("Resolved issues query: %s", query)
 	}
 	resolvedIssues, _, err := client.Issue.Search(query, nil)
+	if verbose {
+		log.Printf("Resolved issues result: %s", spew.Dump(resolvedIssues))
+	}
 	if err != nil {
 		log.Printf("Error querying JIRA for resolved issues: %v\n", err)
 		return nil, err

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -218,10 +218,10 @@ func periodicJIRANotifyResolved() (ret []bot.CmdResult, err error) {
 	}
 	for _, issue := range resolvedIssues {
 		channels := notifyResConfig[issue.Fields.Project.Key]
-		threadName := notifyResConfig[issue.Fields.Thread.Key][0]
 		for _, notifyChan := range channels {
+			threadName := channelConfigs[notifyChan].Thread
 			if thread {
-				notifyChan += ":" + notifyChan + "/threads/" + threadName
+				notifyChan += ":" + notifyChan + threadName
 			}
 			if verbose {
 				log.Printf("Notifying %s about resolved %s %s", notifyChan,


### PR DESCRIPTION
This PR contains two changes in one. Please let me know if you'd prefer to split them up.

* Adds support for monitoring components
Some Jira projects use components to track smaller parts. This allows the bot to monitor for those components, and send the notifications to chat rooms/channels which are specific for them.

* Add support for Google Chat threads
Originally each time the bot sends a self-initiated message to a Google Chat room it initializes a new thread. This patch adds support for sending notifications to the same thread. The only caveat is that, because of Google Chat API limitations, the thread needs to pre-exist (that's reflected in the documentation).

I tried to make this semi-independent of the protocol being used, such that it can be modified to use threads in other outputs like Slack, however right now I don't have access to other chat tools that use threads to test.

NOTE: in the patch you will see some unrelated lines of code being changed. That's because I use Visual Studio Code, and it has the habit of trying to re-format surrounding code when you start making changes. Sorry for that.